### PR TITLE
Feature/static sidebar bbox map

### DIFF
--- a/app/assets/stylesheets/modules/_sidebar.scss
+++ b/app/assets/stylesheets/modules/_sidebar.scss
@@ -1,0 +1,3 @@
+.page-sidebar [data-map="item"] {
+  height: 280px;
+}

--- a/app/assets/stylesheets/umass.scss
+++ b/app/assets/stylesheets/umass.scss
@@ -3,6 +3,7 @@
 @import 'modules/header';
 @import 'modules/homepage';
 @import 'modules/footer';
+@import 'modules/sidebar';
 @import 'modules/type';
 
 // Button primary

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,0 +1,14 @@
+<%= render :partial => 'show_tools' %>
+
+<%= render :partial => "show_downloads" %>
+
+<% unless @document.more_like_this.empty? %>
+  <div class="card">
+    <div class="card-header">More Like This</div>
+    <div class="card-body">
+      <%= render :collection => @document.more_like_this, :partial => 'show_more_like_this', :as => :document %>
+    </div>
+  </div>
+<% end %>
+
+<%= render :partial => 'show_sidebar_static_map_bbox' %>

--- a/app/views/catalog/_show_sidebar_static_map_bbox.html.erb
+++ b/app/views/catalog/_show_sidebar_static_map_bbox.html.erb
@@ -1,0 +1,23 @@
+<% if ['iiif', 'iiif_manifest'].any?{ |vp| @document.viewer_protocol == vp } %>
+
+  <%-
+    # Compare with render_document_functions_partial helper, and
+    # _document_functions partial. BL actually has two groups
+    # of document-related tools. "document functions" by default
+    # contains Bookmark functionality shown on both results and
+    # item view. While "document tools" contains external export type
+    # functions by default only on detail.
+
+  -%>
+  <div class="card location">
+    <div class="card-header">
+      Location
+    </div>
+
+    <div class="card-body">
+      <%= content_tag :div, id: 'static-map', data: { map: 'item', protocol: 'Map', url: @document.viewer_endpoint, 'layer-id' => @document.wxs_identifier, 'map-geom' => @document.geometry.geojson, 'catalog-path'=> search_catalog_path, available: document_available?, inspect: show_attribute_table?, basemap: 'positron', leaflet_options: leaflet_options } do %>
+      <% end %>
+    </div>
+  </div>
+
+<% end %>

--- a/test/system/homepage_test.rb
+++ b/test/system/homepage_test.rb
@@ -6,9 +6,9 @@ class HomepageTest < ApplicationSystemTestCase
   end
 
   def test_basic_dom
-    assert page.has_selector?('#umass--global--header') # Global Header
+    assert page.has_selector?('header') # Global Header
     assert page.has_selector?('ul.navbar-nav')          # Navbar
-    assert page.has_selector?('#umass--global--footer') # Global Footer
+    assert page.has_selector?('footer') # Global Footer
   end
 
   def test_homepage_copy

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -42,4 +42,18 @@ class ShowPageTest < ApplicationSystemTestCase
       assert page.has_selector?("div.page-links")            # Pagination
     end
   end
+
+  def test_sidebar_bbox_map
+    # Viewer: IIIF
+    visit '/catalog/umass-mufs190-1951-dpl2k101-i001'
+    within(".page-sidebar") do
+      assert page.has_selector?(".card.location")
+    end
+
+    # Viewer: Map
+    visit '/catalog/2eddde2f-c222-41ca-bd07-2fd74a21f4de'
+    within(".page-sidebar") do
+      assert page.has_no_selector?(".card.location")
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a static map to the show page sidebar for IIIF images. Shows where the image bbox falls on the map.

![GeoData_Show_Page](https://user-images.githubusercontent.com/69827/111689129-a16fd780-87f9-11eb-95eb-9c204b22396c.png)
