### PR TITLE
updated fixtures to align with aardvark

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,7 +44,7 @@ FIELDS:
   :TITLE: 'dct_title_s'
   :UNIQUE_KEY: 'id'
   :WXS_IDENTIFIER: 'dcat_servesDataset_s'
-  :YEAR: 'gbl_indexYear_i'
+  :YEAR: 'gbl_indexYear_im'
   :ANNOTATION: 'umass_annotated_s'
 
 # Institution deployed at

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpl2k101-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpl2k101-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Bourne, MA, 1951 (dpl-2k-101)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of Bourne (Town of Bourne, Barnstable County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-22",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-22",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        "4931050"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "Bourne, MA",
         "Town of Bourne, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpl2k101-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpl2k101-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpl2k101-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpl2k101-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpl2k101-i001",
     "dct_identifier_sm": "mufs190-1951-dpl2k101-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        "4931050"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpl2k3-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpl2k3-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Sandwich, MA, 1951 (dpl-2k-3)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of Scorton Shores (Town of Sandwich, Barnstable County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-22",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-22",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        "4950427"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "Scorton Shores, MA",
         "Town of Sandwich, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpl2k3-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpl2k3-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpl2k3-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpl2k3-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpl2k3-i001",
     "dct_identifier_sm": "mufs190-1951-dpl2k3-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        "4950427"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpl2k4-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpl2k4-i001.json
@@ -1,34 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): City of Barnstable Town, MA, 1951 (dpl-2k-4)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of West Barnstable (City of Barnstable Town, Barnstable County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-22",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-22",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "full",
-    "umass_geonames_sm": [
-        "4832322",
-        "4950427"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "West Barnstable, MA",
         "City of Barnstable Town, MA",
@@ -44,8 +37,13 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpl2k4-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpl2k4-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpl2k4-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpl2k4-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpl2k4-i001",
     "dct_identifier_sm": "mufs190-1951-dpl2k4-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "Whole image",
+    "umass_geonames_sm": [
+        "4832322",
+        "4950427"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpl2k5-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpl2k5-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): City of Barnstable Town, MA, 1951 (dpl-2k-5)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of West Barnstable (City of Barnstable Town, Barnstable County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-22",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-22",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        "4832322"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "West Barnstable, MA",
         "City of Barnstable Town, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpl2k5-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpl2k5-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpl2k5-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpl2k5-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpl2k5-i001",
     "dct_identifier_sm": "mufs190-1951-dpl2k5-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        "4832322"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpl2k6-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpl2k6-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): City of Barnstable Town, MA, 1951 (dpl-2k-6)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of West Barnstable (City of Barnstable Town, Barnstable County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-22",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-22",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "full",
-    "umass_geonames_sm": [
-        "4832322"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "West Barnstable, MA",
         "City of Barnstable Town, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpl2k6-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpl2k6-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpl2k6-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpl2k6-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpl2k6-i001",
     "dct_identifier_sm": "mufs190-1951-dpl2k6-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "Whole image",
+    "umass_geonames_sm": [
+        "4832322"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpn1k100-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpn1k100-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Dighton, MA, 1951 (dpn-1k-100)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of West Dighton (Town of Dighton, Bristol County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-20",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-20",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        "4954932"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "West Dighton, MA",
         "Town of Dighton, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpn1k100-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpn1k100-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpn1k100-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpn1k100-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpn1k100-i001",
     "dct_identifier_sm": "mufs190-1951-dpn1k100-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        "4954932"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpn1k101-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpn1k101-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Dighton, MA, 1951 (dpm-1k-101)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of West Dighton (Town of Dighton, Bristol County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-20",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-20",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "full",
-    "umass_geonames_sm": [
-        "4954932"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "West Dighton, MA",
         "Town of Dighton, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpn1k101-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpn1k101-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpn1k101-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpn1k101-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpn1k101-i001",
     "dct_identifier_sm": "mufs190-1951-dpn1k101-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "Whole image",
+    "umass_geonames_sm": [
+        "4954932"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpn1k102-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpn1k102-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Rehoboth, MA, 1951 (dpn-1k-102)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of North Rehoboth (Town of Rehoboth, Bristol County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-20",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-20",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        ""
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "North Rehoboth, MA",
         "Town of Rehoboth, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpn1k102-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpn1k102-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpn1k102-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpn1k102-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpn1k102-i001",
     "dct_identifier_sm": "mufs190-1951-dpn1k102-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        ""
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpn1k103-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpn1k103-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Rehoboth, MA, 1951 (dpn-1k-103)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of North Rehoboth (Town of Rehoboth, Bristol County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-20",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-20",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "full",
-    "umass_geonames_sm": [
-        "4945740"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "North Rehoboth, MA",
         "Town of Rehoboth, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpn1k103-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpn1k103-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpn1k103-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpn1k103-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpn1k103-i001",
     "dct_identifier_sm": "mufs190-1951-dpn1k103-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "Whole image",
+    "umass_geonames_sm": [
+        "4945740"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1951-dpn1k104-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1951-dpn1k104-i001.json
@@ -1,33 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Rehoboth, MA, 1951 (dpn-1k-104)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1951 of North Rehoboth (Town of Rehoboth, Bristol County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1951-10-20",
+    "dct_temporal_sm": "1951",
     "dct_issued_s": "1951-10-20",
-    "gbl_indexYear_i": 1951,
-    "umass_annotated_s": "none",
-    "umass_geonames_sm": [
-        "4945740"
-    ],
+    "gbl_indexYear_im": 1951,
     "dct_spatial_sm": [
         "North Rehoboth, MA",
         "Town of Rehoboth, MA",
@@ -43,8 +37,12 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1951-dpn1k104-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1951-dpn1k104-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1951-dpn1k104-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1951-dpn1k104-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1951-dpn1k104-i001",
     "dct_identifier_sm": "mufs190-1951-dpn1k104-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "None",
+    "umass_geonames_sm": [
+        "4945740"
+    ]
 }

--- a/test/fixtures/files/umass_documents/mufs190-1952-dpb6h54-i001.json
+++ b/test/fixtures/files/umass_documents/mufs190-1952-dpb6h54-i001.json
@@ -1,35 +1,27 @@
 {
     "dct_title_s": "1:20k Aerial Photograph (B/W): Town of Amherst, MA, 1952 (dpb-6h-54)",
     "dct_description_sm": "Georeferenced black-and-white aerial photograph captured in 1952 of North Amherst (Town of Amherst, Hampshire County, MA). The photograph was scanned and manually georeferenced in ArcMap 10.8 against 2019 color orthoimagery from the U.S. Geological Survey.",
-    "dct_language_sm": "English",
+    "dct_language_sm": "eng",
     "dct_creator_sm": "MacConnell, William Preston, 1918-",
     "dct_publisher_sm": "University of Massachusetts at Amherst. Department of Forestry and Wildlife Management",
     "schema_provider_s": "UMass",
     "gbl_resourceClass_sm": "Imagery",
-    "gbl_resourceType_sm": "Raster",
+    "gbl_resourceType_sm": "Aerial photographs",
     "dct_subject_sm": [
         "Environment",
         "Imagery and Base Maps",
-        "Land Cover",
         "Planning and Cadastral",
         "Structure"
     ],
     "dcat_theme_sm": [
-        "environment",
-        "imageryBaseMapsEarthCover",
-        "inlandWaters",
-        "planningCadastre",
-        "structure"
+        "Environment",
+        "Imagery and Base Maps",
+        "Planning and Cadastral",
+        "Structure"
     ],
-    "dct_temporal_sm": "1952-06-16",
+    "dct_temporal_sm": "1952",
     "dct_issued_s": "1952-06-16",
-    "gbl_indexYear_i": 1952,
-    "umass_annotated_s": "partial",
-    "umass_geonames_sm": [
-        "4945497",
-        "4936084",
-        "4934376"
-    ],
+    "gbl_indexYear_im": 1952,
     "dct_spatial_sm": [
         "North Amherst, MA",
         "Town of Amherst, MA",
@@ -45,8 +37,14 @@
     "dct_references_s": "{\"http://schema.org/url\":\"https://credo.library.umass.edu/view/full/mufs190-1952-dpb6h54-i001\",\"http://schema.org/downloadUrl\":[{\"url\":\"https://credo.library.umass.edu/media/mufs190-1952-dpb6h54-i001.reference.tif\",\"label\":\"GeoTIFF\"},{\"url\":\"https://credo.library.umass.edu/images/resize/full/mufs190-1952-dpb6h54-i001-001.jpg\",\"label\":\"High-Res JPG\"}],\"http://iiif.io/api/image\":\"https://credo.library.umass.edu/iiif/mufs190-1952-dpb6h54-i001-001.tif/info.json\"}",
     "id": "umass-mufs190-1952-dpb6h54-i001",
     "dct_identifier_sm": "mufs190-1952-dpb6h54-i001",
-    "gbl_mdModified_dt": "2021-08-27T17:38:46Z",
+    "gbl_mdModified_dt": "2021-09-10T20:02:16Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false,
-    "gbl_georeferenced_b": true
+    "gbl_georeferenced_b": true,
+    "umass_annotated_s": "Part of image",
+    "umass_geonames_sm": [
+        "4945497",
+        "4936084",
+        "4934376"
+    ]
 }


### PR DESCRIPTION
A few tweaks to the aardvark schema have been made. Updated the UMass fixtures to align with them.

Note that I attempted to update the fixtures for the GBL documents (which were updated in the summer 2021 sprint) but they broke my version of GBL. I assume I'll need to upgrade to 3.4 at the least to get them to work properly.